### PR TITLE
Integrate Banner Service into Online Shop Demo with Skaffold Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/bannerservice"]
+	path = src/bannerservice
+	url = https://github.com/MaximilianSchreff/banner-microservice.git

--- a/kubernetes-manifests/bannerservice.yaml
+++ b/kubernetes-manifests/bannerservice.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bannerservice
+  labels:
+    app: bannerservice
+spec:
+  selector:
+    matchLabels:
+      app: bannerservice
+  template:
+    metadata:
+      labels:
+        app: bannerservice
+    spec:
+      serviceAccountName: bannerservice
+      terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+      - name: bannerservice
+        image: bannerservice
+        ports:
+        - containerPort: 51234
+        env:
+        - name: PORT
+          value: "51234"
+        # readinessProbe:
+        #   periodSeconds: 5
+        #   grpc:
+        #     port: 51234
+        # livenessProbe:
+        #   periodSeconds: 5
+        #   grpc:
+        #     port: 51234
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bannerservice
+  labels:
+    app: bannerservice
+spec:
+  type: ClusterIP
+  selector:
+    app: bannerservice
+  ports:
+  - name: grpc
+    port: 51234
+    targetPort: 51234
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bannerservice
+

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -88,6 +88,8 @@ spec:
           #   value: "aws"
           - name: ENABLE_PROFILER
             value: "0"
+          - name: BANNER_SERVICE_ADDR
+            value: "bannerservice:51234"
           # - name: CYMBAL_BRANDING
           #   value: "true"
           # - name: ENABLE_ASSISTANT

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -46,6 +46,10 @@ build:
     context: src/frontend
   - image: adservice
     context: src/adservice
+  # - image: bannerservice
+  #   context: src/bannerservice
+  #   docker:
+  #     dockerfile: Dockerfile
   tagPolicy:
     gitCommit: {}
   local:
@@ -54,6 +58,8 @@ manifests:
   kustomize:
     paths:
     - kubernetes-manifests
+  # rawYaml:
+  # - ./kubernetes-manifests/bannerservice.yaml
 deploy:
   kubectl: {}
 # "gcb" profile allows building and pushing the images
@@ -105,6 +111,30 @@ build:
 manifests:
   rawYaml:
   - ./kubernetes-manifests/loadgenerator.yaml
+deploy:
+  kubectl: {}
+profiles:
+- name: gcb
+  build:
+    googleCloudBuild:
+      diskSizeGb: 300
+      machineType: N1_HIGHCPU_32
+      timeout: 4000s
+---
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: bannerservice
+requires:
+- configs:
+  - app
+build:
+  artifacts:
+  - image: bannerservice
+    context: src/bannerservice
+manifests:
+  rawYaml:
+  - ./kubernetes-manifests/bannerservice.yaml
 deploy:
   kubectl: {}
 profiles:


### PR DESCRIPTION
This PR integrates the banner-service microservice into the online shop demo repository. The changes include:

- Adding the banner-service repository as a submodule in src/bannerservice.
- Creating a Kubernetes deployment and service manifest for the banner service (kubernetes-manifests/bannerservice.yaml).
- Updating the skaffold.yaml configuration to include the banner service build and deployment.
- Testing the banner service integration using the test client from the banner-service repository, confirming successful interaction -after deployment.

Testing:

- Deployed the online shop using skaffold dev and verified all services, including the banner service, stabilized successfully.
- Ran the test client from the banner-service repository to confirm the banner service responded correctly to gRPC requests.

Notes:

- The banner service's readiness and liveness probes integration (used by other microservices in this repo) was not done 